### PR TITLE
Add 48kHz support, disable AGC

### DIFF
--- a/app/res/values/strings.xml
+++ b/app/res/values/strings.xml
@@ -218,6 +218,23 @@
         <item>48000</item>
     </string-array>
 
+    <!-- Android API MediaRecorder.AudioSource -->
+    <string name="titleMicrophoneMode">Microphone settings</string>
+    <string name="summaryMicrophoneMode">See MediaRecorder.AudioSource documentation</string>
+
+    <string-array name="entriesMicrophoneMode" translatable="false">
+        <item>VOICE_RECOGNITION (should disable AGC)</item>
+        <item>MIC (may have AGC)</item>
+    </string-array>
+
+    <string name="defaultMicrophoneMode" translatable="false">VOICE_RECOGNITION</string>
+
+    <!-- Unfortunately cannot use an integer array -->
+    <string-array name="valuesMicrophoneMode" translatable="false">
+        <item>VOICE_RECOGNITION</item>
+        <item>MIC</item>
+    </string-array>
+
     <!-- Wait length -->
     <string name="titleTranscribingWaitLength">Waiting coefficient</string>
     <string name="summaryTranscribingWaitLength">Expect the transcription to be complete after X seconds, where X is the duration of the recording multiplied by this value</string>

--- a/app/res/values/strings.xml
+++ b/app/res/values/strings.xml
@@ -199,10 +199,11 @@
 
     <string-array name="entriesRecordingRate" translatable="false">
         <item>8 kHz</item>
-        <item>11 kHz</item>
+        <item>11.025 kHz</item>
         <item>16 kHz</item>
-        <item>22 kHz</item>
-        <item>44 kHz</item>
+        <item>22.05 kHz</item>
+        <item>44.1 kHz</item>
+        <item>48 kHz</item>
     </string-array>
 
     <string name="defaultRecordingRate" translatable="false">16000</string>
@@ -214,6 +215,7 @@
         <item>16000</item>
         <item>22050</item>
         <item>44100</item>
+        <item>48000</item>
     </string-array>
 
     <!-- Wait length -->

--- a/app/res/xml/preferences.xml
+++ b/app/res/xml/preferences.xml
@@ -36,6 +36,14 @@ BUG: try these:
 				android:defaultValue="@string/defaultRecordingRate"
 				android:entries="@array/entriesRecordingRate"
 				android:entryValues="@array/valuesRecordingRate" />
+
+			<ListPreference
+				android:key="microphoneMode"
+				android:title="@string/titleMicrophoneMode"
+				android:summary="@string/summaryMicrophoneMode"
+				android:defaultValue="@string/defaultMicrophoneMode"
+				android:entries="@array/entriesMicrophoneMode"
+				android:entryValues="@array/valuesMicrophoneMode" />
 		</PreferenceScreen>
 	</PreferenceCategory>
 

--- a/app/src/kaljurand_at_gmail_dot_com/diktofon/activity/RecorderActivity.java
+++ b/app/src/kaljurand_at_gmail_dot_com/diktofon/activity/RecorderActivity.java
@@ -32,6 +32,7 @@ import android.content.Intent;
 import android.content.ServiceConnection;
 import android.content.res.Resources;
 import android.media.AudioFormat;
+import android.media.MediaRecorder;
 import android.net.Uri;
 import android.os.Bundle;
 import android.os.Handler;
@@ -55,6 +56,8 @@ public class RecorderActivity extends AbstractDiktofonActivity {
 	public static final String EXTRA_HIGH_RESOLUTION = "HIGH_RESOLUTION";
 	// Recording sample rate (int, default: 16000, i.e. 16 kHz)
 	public static final String EXTRA_SAMPLE_RATE = "SAMPLE_RATE";
+	// Recording Microphone Mode (String, default: VOICE_RECOGNITION)
+	public static final String EXTRA_MICROPHONE_MODE = "VOICE_RECOGNITION";
 
 	private File mRecordingsDir = null;
 
@@ -71,6 +74,7 @@ public class RecorderActivity extends AbstractDiktofonActivity {
 	private boolean mHighResolution = true;
 	private int mResolution = AudioFormat.ENCODING_PCM_16BIT;
 	private int mSampleRate = 16000;
+	private int mMicrophoneMode = MediaRecorder.AudioSource.VOICE_RECOGNITION;
 
 	private String mVolumeBar;
 
@@ -83,7 +87,7 @@ public class RecorderActivity extends AbstractDiktofonActivity {
 			mService = ((RecorderService.RecorderBinder) service).getService();
 
 			try {
-				mService.startRecording(mSampleRate, mResolution, getRecordingFile());
+				mService.startRecording(mMicrophoneMode, mSampleRate, mResolution, getRecordingFile());
 				setRecorderStyle(getResources().getColor(R.color.processing));
 				setButtonRecording();
 				startTasks();
@@ -147,6 +151,15 @@ public class RecorderActivity extends AbstractDiktofonActivity {
 			baseDir = extras.getString(EXTRA_BASE_DIR);
 			mHighResolution = extras.getBoolean(EXTRA_HIGH_RESOLUTION);
 			mSampleRate = extras.getInt(EXTRA_SAMPLE_RATE);
+			String microphoneModeName = extras.getString(EXTRA_MICROPHONE_MODE);
+			if(microphoneModeName.equals("VOICE_RECOGNITION")) {
+				mMicrophoneMode = MediaRecorder.AudioSource.VOICE_RECOGNITION;
+			} else if(microphoneModeName.equals("MIC")) {
+				mMicrophoneMode = MediaRecorder.AudioSource.MIC;
+			} else {
+				Log.e("Invalid microphoneMode: " + microphoneModeName + ", using default");
+				mMicrophoneMode = MediaRecorder.AudioSource.VOICE_RECOGNITION;
+			}
 		}
 
 		if (baseDir == null) {

--- a/app/src/kaljurand_at_gmail_dot_com/diktofon/activity/RecordingListActivity.java
+++ b/app/src/kaljurand_at_gmail_dot_com/diktofon/activity/RecordingListActivity.java
@@ -234,6 +234,7 @@ public class RecordingListActivity extends AbstractDiktofonListActivity {
 					intent.putExtra(RecorderActivity.EXTRA_HIGH_RESOLUTION, false);
 				}
 				intent.putExtra(RecorderActivity.EXTRA_SAMPLE_RATE, Integer.parseInt(mPrefs.getString("recordingRate", getString(R.string.defaultRecordingRate))));
+				intent.putExtra(RecorderActivity.EXTRA_MICROPHONE_MODE, mPrefs.getString("microphoneMode", getString(R.string.defaultMicrophoneMode)));
 				startActivityForResult(intent, MY_ACTIVITY_RECORD_SOUND);
 			} else {
 				Intent intent = new Intent(MediaStore.Audio.Media.RECORD_SOUND_ACTION);

--- a/app/src/kaljurand_at_gmail_dot_com/diktofon/service/RecorderService.java
+++ b/app/src/kaljurand_at_gmail_dot_com/diktofon/service/RecorderService.java
@@ -193,10 +193,10 @@ public class RecorderService extends DiktofonService {
 	 * @param recordingFile File to store the raw audio into
 	 * @throws IOException if recorder could not be created or file is not writable
 	 */
-	public void startRecording(int sampleRate, int resolution, File recordingFile) throws IOException {
+	public void startRecording(int microphoneMode, int sampleRate, int resolution, File recordingFile) throws IOException {
 		mRecordingFile = recordingFile;
 		// RawRecorder(int audioSource, int sampleRate, int channelConfig, int audioFormat)
-		mRecorder = new RawRecorder(MediaRecorder.AudioSource.MIC, sampleRate, AudioFormat.CHANNEL_CONFIGURATION_MONO, resolution);
+		mRecorder = new RawRecorder(microphoneMode, sampleRate, AudioFormat.CHANNEL_CONFIGURATION_MONO, resolution);
 		if (mRecorder.getState() == RawRecorder.State.ERROR) {
 			mRecorder = null;
 			throw new IOException(getString(R.string.error_cant_create_recorder));


### PR DESCRIPTION

48kHz support is common in better Android devices.  48kHz recordings are useful when combining multiple audio files from different sources.

Disabling AGC is necessary for making high quality recordings, especially when using external microphones.  According to the Android docs, choosing the VOICE_RECOGNITION mode should disable AGC.  Some Android devices fail to respect this but it seems to work OK for me.